### PR TITLE
Fix error when the file inside gzip doesn't have the same name as the gzip itself.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         platform: [win]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v1
@@ -31,7 +31,7 @@ jobs:
           msbuild /m /t:restore,getlumiabsp:publish /p:Platform=${{ matrix.architecture }} /p:RuntimeIdentifier=${{ matrix.platform }}-${{ matrix.architecture }} /p:PublishDir=${{ github.workspace }}/artifacts/${{ matrix.platform }}-${{ matrix.architecture }} /p:PublishSingleFile=true /p:PublishTrimmed=true GetLumiaBSP.sln
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform }}-${{ matrix.architecture }}
           path: ${{ github.workspace }}/artifacts/${{ matrix.platform }}-${{ matrix.architecture }}

--- a/GetLumiaBSP/BSPExtractor/Program.cs
+++ b/GetLumiaBSP/BSPExtractor/Program.cs
@@ -450,17 +450,17 @@ namespace BSPExtractor
                 {
                     string path = NewDrive + @"\Windows\Packages\DsmFiles\" + packagename;
 
-                    RunProgram("7za.exe", "x " + path);
+                    RunProgram("7za.exe", "e " + path + " -o" + packagename);
 
-                    Stream stream = File.OpenRead(packagename.Replace(".xml", ""));
-                    //Stream stream = File.OpenRead(path);//
+                    string pathreal = Directory.EnumerateFiles(packagename, "*.dsm", SearchOption.TopDirectoryOnly).ElementAt(0);
+                    Stream stream = File.OpenRead(pathreal);
 
                     XmlSerializer serializer = new(typeof(XmlDsm.Package));
                     XmlDsm.Package package = (XmlDsm.Package)serializer.Deserialize(stream);
 
                     stream.Close();
 
-                    File.Delete(packagename.Replace(".xml", ""));
+                    Directory.Delete(packagename, true);
 
                     List<XmlDsm.FileEntry>? entries = package.Files.FileEntry;
 


### PR DESCRIPTION
Fixes crash with Lumia 920 MainOS.